### PR TITLE
feat: add multi-account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,62 @@ mog auth status
 
 ---
 
+## 👥 Multi-Account Support
+
+Manage multiple Microsoft 365 accounts (personal, work, etc.):
+
+### Setup Additional Accounts
+
+```bash
+# Login with a named account
+mog auth login --client-id YOUR_CLIENT_ID --account work
+mog auth login --client-id YOUR_CLIENT_ID --account personal
+```
+
+### Using Accounts
+
+```bash
+# Specify account per-command
+mog mail search "*" --account work
+mog calendar list --account personal
+
+# Or set via environment variable
+export MOG_ACCOUNT=work
+mog mail search "*"
+```
+
+### List Configured Accounts
+
+```bash
+mog auth list
+```
+
+### Account Storage
+
+Each account has isolated storage:
+```
+~/.config/mog/
+  default/
+    settings.json
+    tokens.json
+    slugs.json
+  work/
+    settings.json
+    tokens.json
+    slugs.json
+```
+
+Existing single-account setups are auto-migrated to `default`.
+
+---
+
 ## 📖 Command Reference
 
 ### Global Options
 
 | Option | Description |
 |--------|-------------|
+| `--account`, `-a` | Account name (default: "default", env: `MOG_ACCOUNT`) |
 | `--json` | Output JSON (best for scripting) |
 | `--plain` | Stable text output (TSV, no colors) |
 | `--verbose` | Show full IDs and extra details |

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,20 +91,43 @@ mog generates 8-character slugs for Microsoft's long GUIDs:
 - `mog cal` → `mog calendar`
 - `mog todo` → `mog tasks`
 
+## Multi-Account Support
+
+Manage multiple Microsoft 365 accounts (personal, work, etc.):
+
+```bash
+# Setup additional accounts
+mog auth login --client-id YOUR_CLIENT_ID --account work
+mog auth login --client-id YOUR_CLIENT_ID --account personal
+
+# Use specific account
+mog mail search "*" --account work
+mog calendar list --account personal
+
+# Or set via environment variable
+export MOG_ACCOUNT=work
+mog mail search "*"
+
+# List configured accounts
+mog auth list
+```
+
 ## Credential Storage
 
 OAuth tokens stored in config directory (0600 permissions):
 
 | Platform | Location |
 |----------|----------|
-| **macOS** | `~/.config/mog/` |
-| **Linux** | `~/.config/mog/` |
-| **Windows** | `%USERPROFILE%\.config\mog\` |
+| **macOS** | `~/.config/mog/{account}/` |
+| **Linux** | `~/.config/mog/{account}/` |
+| **Windows** | `%USERPROFILE%\.config\mog\{account}\` |
 
-Files:
-- `tokens.json` - OAuth tokens (encrypted at rest by OS)
+Files per account:
+- `tokens.json` - OAuth tokens
 - `settings.json` - Client ID
 - `slugs.json` - Slug cache
+
+Default account is `default`. Existing single-account setups auto-migrate.
 
 ## See Also
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -15,6 +15,7 @@ type AuthCmd struct {
 	Login  AuthLoginCmd  `cmd:"" help:"Login to Microsoft 365"`
 	Status AuthStatusCmd `cmd:"" help:"Show authentication status"`
 	Logout AuthLogoutCmd `cmd:"" help:"Logout and clear tokens"`
+	List   AuthListCmd   `cmd:"" help:"List configured accounts"`
 }
 
 // AuthLoginCmd logs in to Microsoft 365.
@@ -39,7 +40,7 @@ func (c *AuthLoginCmd) Run(root *Root) error {
 	}
 
 	// Request device code
-	fmt.Println("Requesting device code...")
+	fmt.Printf("Requesting device code for account '%s'...\n", config.GetAccount())
 	dcResp, err := graph.RequestDeviceCode(c.ClientID)
 	if err != nil {
 		return fmt.Errorf("failed to request device code: %w", err)
@@ -65,7 +66,7 @@ func (c *AuthLoginCmd) Run(root *Root) error {
 	}
 
 	fmt.Println()
-	fmt.Printf("✓ Successfully logged in! (storage: %s)\n", c.Storage)
+	fmt.Printf("✓ Successfully logged in as account '%s' (storage: %s)\n", config.GetAccount(), c.Storage)
 	return nil
 }
 
@@ -79,6 +80,8 @@ func (c *AuthStatusCmd) Run(root *Root) error {
 	if cfg != nil && cfg.Storage == "keychain" {
 		config.SetStorage(config.StorageKeyring)
 	}
+
+	fmt.Printf("Account: %s\n", config.GetAccount())
 
 	tokens, err := config.LoadTokensAuto()
 	if err != nil {
@@ -127,7 +130,38 @@ func (c *AuthLogoutCmd) Run(root *Root) error {
 		return fmt.Errorf("failed to clear slugs: %w", err)
 	}
 
-	fmt.Println("✓ Logged out successfully")
+	fmt.Printf("✓ Logged out from account '%s' successfully\n", config.GetAccount())
+	return nil
+}
+
+// AuthListCmd lists configured accounts.
+type AuthListCmd struct{}
+
+// Run executes the auth list command.
+func (c *AuthListCmd) Run(root *Root) error {
+	accounts, err := config.ListAccounts()
+	if err != nil {
+		return fmt.Errorf("failed to list accounts: %w", err)
+	}
+
+	if len(accounts) == 0 {
+		fmt.Println("No accounts configured.")
+		fmt.Println("Run: mog auth login --client-id YOUR_CLIENT_ID")
+		return nil
+	}
+
+	currentAccount := config.GetAccount()
+	fmt.Println("Configured accounts:")
+	for _, account := range accounts {
+		if account == currentAccount {
+			fmt.Printf("  * %s (current)\n", account)
+		} else {
+			fmt.Printf("    %s\n", account)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Use --account NAME or MOG_ACCOUNT=NAME to switch accounts.")
 	return nil
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/visionik/mogcli/internal/config"
 	"github.com/visionik/mogcli/internal/graph"
 )
 
@@ -15,6 +16,7 @@ type ClientFactory func() (graph.Client, error)
 // Root is the top-level CLI structure.
 type Root struct {
 	// Global flags
+	Account string      `help:"Account name for multi-account support" env:"MOG_ACCOUNT" default:"default" short:"a"`
 	AIHelp  bool        `name:"ai-help" help:"Show detailed help for AI/LLM agents"`
 	JSON    bool        `help:"Output JSON to stdout (best for scripting)" xor:"format"`
 	Plain   bool        `help:"Output stable, parseable text to stdout (TSV; no colors)" xor:"format"`
@@ -38,6 +40,23 @@ type Root struct {
 	// ClientFactory allows injecting a custom client factory for testing.
 	// If nil, graph.NewClient is used.
 	ClientFactory ClientFactory `kong:"-"`
+}
+
+// AfterApply runs after flags are parsed but before the command executes.
+// This sets up the account context for all commands.
+func (r *Root) AfterApply() error {
+	// Set the active account
+	config.SetAccount(r.Account)
+
+	// Migrate legacy config if needed (first run after upgrade)
+	if err := config.MigrateIfNeeded(); err != nil {
+		// Non-fatal, just log if verbose
+		if r.Verbose {
+			fmt.Fprintf(os.Stderr, "Warning: migration check failed: %v\n", err)
+		}
+	}
+
+	return nil
 }
 
 // GetClient returns a Graph client using the configured factory or default.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,25 @@ import (
 	"path/filepath"
 )
 
+// currentAccount holds the active account name.
+// Default is "default" for backward compatibility.
+var currentAccount = "default"
+
+// SetAccount sets the active account name.
+// Empty string is treated as "default".
+func SetAccount(name string) {
+	if name == "" {
+		currentAccount = "default"
+	} else {
+		currentAccount = name
+	}
+}
+
+// GetAccount returns the current account name.
+func GetAccount() string {
+	return currentAccount
+}
+
 // Config holds mog configuration.
 // Compatible with both Go and Node mog formats.
 type Config struct {
@@ -52,13 +71,89 @@ type Slugs struct {
 	SlugToID map[string]string `json:"slug_to_id"`
 }
 
-// ConfigDir returns the config directory path.
-func ConfigDir() (string, error) {
+// BaseConfigDir returns the base config directory (without account).
+func BaseConfigDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(home, ".config", "mog"), nil
+}
+
+// ConfigDir returns the config directory path for the current account.
+func ConfigDir() (string, error) {
+	base, err := BaseConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, currentAccount), nil
+}
+
+// MigrateIfNeeded migrates legacy single-account config to "default" subdirectory.
+func MigrateIfNeeded() error {
+	base, err := BaseConfigDir()
+	if err != nil {
+		return err
+	}
+
+	// Check if legacy tokens.json exists at base level
+	legacyTokens := filepath.Join(base, "tokens.json")
+	defaultDir := filepath.Join(base, "default")
+
+	if _, err := os.Stat(legacyTokens); err == nil {
+		// Legacy config exists, migrate to default/
+		if err := os.MkdirAll(defaultDir, 0700); err != nil {
+			return err
+		}
+
+		// Move tokens.json
+		if err := os.Rename(legacyTokens, filepath.Join(defaultDir, "tokens.json")); err != nil {
+			return err
+		}
+
+		// Move settings.json if exists
+		legacySettings := filepath.Join(base, "settings.json")
+		if _, err := os.Stat(legacySettings); err == nil {
+			os.Rename(legacySettings, filepath.Join(defaultDir, "settings.json"))
+		}
+
+		// Move slugs.json if exists
+		legacySlugs := filepath.Join(base, "slugs.json")
+		if _, err := os.Stat(legacySlugs); err == nil {
+			os.Rename(legacySlugs, filepath.Join(defaultDir, "slugs.json"))
+		}
+	}
+
+	return nil
+}
+
+// ListAccounts returns a list of configured account names.
+func ListAccounts() ([]string, error) {
+	base, err := BaseConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var accounts []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Check if it has tokens.json (is a valid account)
+			tokensPath := filepath.Join(base, entry.Name(), "tokens.json")
+			if _, err := os.Stat(tokensPath); err == nil {
+				accounts = append(accounts, entry.Name())
+			}
+		}
+	}
+
+	return accounts, nil
 }
 
 // Load loads the configuration file.
@@ -115,7 +210,7 @@ func LoadTokens() (*Tokens, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("not logged in. Run: mog auth login")
+			return nil, fmt.Errorf("not logged in. Run: mog auth login --account %s", currentAccount)
 		}
 		return nil, err
 	}

--- a/internal/config/keyring.go
+++ b/internal/config/keyring.go
@@ -9,8 +9,12 @@ import (
 
 const (
 	serviceName = "mog"
-	tokenKey    = "oauth_tokens"
 )
+
+// tokenKeyForAccount returns the keyring key for the current account.
+func tokenKeyForAccount() string {
+	return fmt.Sprintf("oauth_tokens_%s", currentAccount)
+}
 
 // StorageType represents the credential storage backend.
 type StorageType string
@@ -37,15 +41,15 @@ func SaveTokensKeyring(tokens *Tokens) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal tokens: %w", err)
 	}
-	return keyring.Set(serviceName, tokenKey, string(data))
+	return keyring.Set(serviceName, tokenKeyForAccount(), string(data))
 }
 
 // LoadTokensKeyring loads OAuth tokens from the system keyring.
 func LoadTokensKeyring() (*Tokens, error) {
-	data, err := keyring.Get(serviceName, tokenKey)
+	data, err := keyring.Get(serviceName, tokenKeyForAccount())
 	if err != nil {
 		if err == keyring.ErrNotFound {
-			return nil, fmt.Errorf("not logged in. Run: mog auth login")
+			return nil, fmt.Errorf("not logged in. Run: mog auth login --account %s", currentAccount)
 		}
 		return nil, fmt.Errorf("failed to get tokens from keyring: %w", err)
 	}
@@ -59,7 +63,7 @@ func LoadTokensKeyring() (*Tokens, error) {
 
 // DeleteTokensKeyring removes OAuth tokens from the system keyring.
 func DeleteTokensKeyring() error {
-	err := keyring.Delete(serviceName, tokenKey)
+	err := keyring.Delete(serviceName, tokenKeyForAccount())
 	if err != nil && err != keyring.ErrNotFound {
 		return fmt.Errorf("failed to delete tokens from keyring: %w", err)
 	}


### PR DESCRIPTION
## Summary

Add support for managing multiple Microsoft 365 accounts, matching gog's multi-account pattern.

## Changes

### New Features
- **`--account` / `-a` global flag** — specify account per-command
- **`MOG_ACCOUNT` env var** — set default account
- **`mog auth list`** — list configured accounts
- **Auto-migration** — existing configs move to `default/` subdirectory

### Storage Structure
```
~/.config/mog/
  default/
    settings.json
    tokens.json
    slugs.json
  work/
    settings.json
    tokens.json
    slugs.json
```

### Usage
```bash
# Setup multiple accounts
mog auth login --client-id XXX --account work
mog auth login --client-id XXX --account personal

# Use per-command
mog mail search '*' --account work
mog calendar list --account personal

# Or via env var
export MOG_ACCOUNT=work
mog mail search '*'

# List accounts
mog auth list
```

## Files Changed
- `internal/config/config.go` — account-aware config directory, migration, list
- `internal/config/keyring.go` — per-account keyring keys
- `internal/cli/root.go` — `--account` flag + `AfterApply` hook
- `internal/cli/auth.go` — `auth list` command, account display in status/login/logout
- `README.md` — multi-account documentation

## Testing
- [x] `go build ./...` passes
- [x] Manual testing with multiple accounts

## Related
Matches the pattern used by gog (Google Ops Gadget) for consistency across the \*og family.