### PR TITLE
fix: omit null recipients in mail send and improve auth error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,18 @@ go build -o mog ./cmd/mog
 
 1. Go to [Azure Portal](https://portal.azure.com) → **App registrations** → **New registration**
 2. **Name:** `mog CLI` (or any name)
-3. **Supported account types:** Select based on your needs
+3. **Supported account types:** Select **"Accounts in any organizational directory (Any Azure AD directory - Multitenant)"** — single-tenant is not supported with device code flow
 4. **Redirect URI:** Leave blank (uses device code flow)
 
-### 2. Add API Permissions
+### 2. Enable Public Client Flows
+
+1. In your app registration, go to **Authentication** → **Advanced settings**
+2. Set **"Allow public client flows"** to **Yes**
+3. Click **Save**
+
+> ⚠️ Both multitenant and public client flows are **required** for the device code authentication flow that mog uses.
+
+### 3. Add API Permissions
 
 Add these **Delegated** permissions:
 
@@ -109,7 +117,7 @@ Add these **Delegated** permissions:
 | `Tasks.ReadWrite` | Read and write tasks |
 | `Notes.ReadWrite` | Read and write OneNote |
 
-### 3. Authenticate
+### 4. Authenticate
 
 ```bash
 mog auth login --client-id YOUR_CLIENT_ID
@@ -117,7 +125,7 @@ mog auth login --client-id YOUR_CLIENT_ID
 
 Opens a browser for Microsoft login. Tokens stored at `~/.config/mog/tokens.json`.
 
-### 4. Verify
+### 5. Verify
 
 ```bash
 mog auth status

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -178,16 +178,16 @@ func (c *MailSendCmd) Run(root *Root) error {
 	// Reply to existing message
 	if c.ReplyToMessageID != "" {
 		messageID := graph.ResolveID(c.ReplyToMessageID)
-		replyMsg := map[string]interface{}{
-			"message": map[string]interface{}{
-				"body": map[string]string{
-					"contentType": contentType,
-					"content":     body,
-				},
-				"toRecipients":  formatRecipients(c.To),
-				"ccRecipients":  formatRecipients(c.Cc),
-				"bccRecipients": formatRecipients(c.Bcc),
+		message := map[string]interface{}{
+			"body": map[string]string{
+				"contentType": contentType,
+				"content":     body,
 			},
+			"toRecipients": formatRecipients(c.To),
+		}
+		addRecipientsIfPresent(message, c.Cc, c.Bcc)
+		replyMsg := map[string]interface{}{
+			"message": message,
 			"comment": body,
 		}
 		_, err = client.Post(ctx, fmt.Sprintf("/me/messages/%s/reply", messageID), replyMsg)
@@ -195,17 +195,17 @@ func (c *MailSendCmd) Run(root *Root) error {
 			return err
 		}
 	} else {
-		msg := map[string]interface{}{
-			"message": map[string]interface{}{
-				"subject": c.Subject,
-				"body": map[string]string{
-					"contentType": contentType,
-					"content":     body,
-				},
-				"toRecipients":  formatRecipients(c.To),
-				"ccRecipients":  formatRecipients(c.Cc),
-				"bccRecipients": formatRecipients(c.Bcc),
+		message := map[string]interface{}{
+			"subject": c.Subject,
+			"body": map[string]string{
+				"contentType": contentType,
+				"content":     body,
 			},
+			"toRecipients": formatRecipients(c.To),
+		}
+		addRecipientsIfPresent(message, c.Cc, c.Bcc)
+		msg := map[string]interface{}{
+			"message": message,
 		}
 		_, err = client.Post(ctx, "/me/sendMail", msg)
 		if err != nil {
@@ -529,6 +529,18 @@ func formatRecipients(emails []string) []map[string]interface{} {
 		})
 	}
 	return result
+}
+
+// addRecipientsIfPresent adds ccRecipients and bccRecipients to the message map
+// only when non-empty. The Graph API rejects null values for these collection
+// fields even though the spec marks them Nullable=True.
+func addRecipientsIfPresent(msg map[string]interface{}, cc, bcc []string) {
+	if len(cc) > 0 {
+		msg["ccRecipients"] = formatRecipients(cc)
+	}
+	if len(bcc) > 0 {
+		msg["bccRecipients"] = formatRecipients(bcc)
+	}
 }
 
 func printMessage(msg Message, verbose bool) {

--- a/internal/graph/client.go
+++ b/internal/graph/client.go
@@ -239,6 +239,8 @@ type DeviceCodeResponse struct {
 	ExpiresIn       int    `json:"expires_in"`
 	Interval        int    `json:"interval"`
 	Message         string `json:"message"`
+	Error           string `json:"error"`
+	ErrorDesc       string `json:"error_description"`
 }
 
 // TokenResponse is the response from the token request.
@@ -284,6 +286,22 @@ func RequestDeviceCode(clientID string) (*DeviceCodeResponse, error) {
 	var dcResp DeviceCodeResponse
 	if err := json.Unmarshal(body, &dcResp); err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode >= 400 || dcResp.Error != "" {
+		errMsg := dcResp.ErrorDesc
+		if errMsg == "" {
+			errMsg = string(body)
+		}
+		hint := "\n\nEnsure your Azure AD app registration has:\n" +
+			"  1. 'Allow public client flows' set to Yes (Authentication > Advanced settings)\n" +
+			"  2. 'Supported account types' set to multitenant (or multitenant + personal)"
+		return nil, fmt.Errorf("device code request failed: %s%s", errMsg, hint)
+	}
+
+	if dcResp.DeviceCode == "" {
+		return nil, fmt.Errorf("device code response missing device_code — " +
+			"verify your app registration has 'Allow public client flows' enabled")
 	}
 
 	return &dcResp, nil


### PR DESCRIPTION
## Summary

Fixes two user-reported issues:

### 1. `mog mail send` fails with null recipients (#bccRecipients bug)

**Problem:** Graph API rejects `bccRecipients: null` and `ccRecipients: null` in the JSON payload, even though the spec marks them `Nullable=True`. This is a [known MS Graph bug](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/2230).

**Fix:** Only include `ccRecipients`/`bccRecipients` in the payload when non-empty, via a new `addRecipientsIfPresent` helper. Applies to both send and reply paths.

### 2. Confusing AADSTS900144 error during `mog auth login`

**Problem:** When the Azure AD app isn't configured as a public client or multitenant, the `/devicecode` endpoint returns an error. But `RequestDeviceCode` didn't check for errors, resulting in an empty `device_code` and a misleading downstream error.

**Fix:** Parse error responses from the `/devicecode` endpoint and surface actionable hints about the two required app registration settings.

### 3. README setup improvements

Added explicit steps for enabling public client flows and selecting multitenant account type.

## Testing

All existing tests pass, including `successful_send_with_CC_and_BCC` and `reply_to_message`.