### PR TITLE
fix(mail): avoid $orderby together with $search (Graph rejects it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `mail search` / `mail list` no longer send `$orderby` together with `$search`. Microsoft Graph rejects that combination (`SearchWithOrderBy: The query parameter '$orderby' is not supported with '$search'`), so every text search failed. Date sorting is kept for listing (`*` / empty query). Search terms are now escaped for the `$search` phrase (backslash and double quote), and whitespace-only queries are treated as a plain listing. (#11)
+
 ## [0.3.1] - 2026-01-26
 
 ### Added

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -47,6 +47,33 @@ type MailSearchCmd struct {
 	Folder string `help:"Folder ID to search in"`
 }
 
+// escapeSearchTerm escapes a user-provided term for a Graph $search KQL phrase.
+// Inside the quoted phrase, backslashes and double quotes must be
+// backslash-escaped (backslash first, so an escaped quote is not double-escaped).
+func escapeSearchTerm(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
+// buildMailSearchQuery builds the OData query for listing/searching messages.
+// Microsoft Graph rejects $search combined with $orderby ("SearchWithOrderBy:
+// The query parameter '$orderby' is not supported with '$search'"), so $orderby
+// is only applied when not performing a $search. Empty/whitespace and "*" are
+// treated as a plain (sorted) listing.
+func buildMailSearchQuery(q string, max int) url.Values {
+	query := url.Values{}
+	query.Set("$top", fmt.Sprintf("%d", max))
+	query.Set("$select", "id,subject,from,receivedDateTime,isRead,hasAttachments")
+
+	if term := strings.TrimSpace(q); term != "" && term != "*" {
+		query.Set("$search", fmt.Sprintf(`"%s"`, escapeSearchTerm(term)))
+	} else {
+		query.Set("$orderby", "receivedDateTime desc")
+	}
+	return query
+}
+
 // Run executes mail search.
 func (c *MailSearchCmd) Run(root *Root) error {
 	client, err := root.GetClient()
@@ -55,14 +82,7 @@ func (c *MailSearchCmd) Run(root *Root) error {
 	}
 
 	ctx := context.Background()
-	query := url.Values{}
-	query.Set("$top", fmt.Sprintf("%d", c.Max))
-	query.Set("$orderby", "receivedDateTime desc")
-	query.Set("$select", "id,subject,from,receivedDateTime,isRead,hasAttachments")
-
-	if c.Query != "*" && c.Query != "" {
-		query.Set("$search", fmt.Sprintf(`"%s"`, c.Query))
-	}
+	query := buildMailSearchQuery(c.Query, c.Max)
 
 	path := "/me/messages"
 	if c.Folder != "" {

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -970,3 +970,59 @@ func mustJSON(data interface{}) []byte {
 	}
 	return b
 }
+
+func TestBuildMailSearchQuery(t *testing.T) {
+	// Free-text search must NOT include $orderby — Graph rejects the
+	// combination ("SearchWithOrderBy").
+	q := buildMailSearchQuery("hello", 25)
+	assert.Equal(t, `"hello"`, q.Get("$search"))
+	assert.Empty(t, q.Get("$orderby"))
+	assert.Equal(t, "25", q.Get("$top"))
+
+	// Listing (* or empty) sorts by date and performs no $search.
+	for _, all := range []string{"*", ""} {
+		q := buildMailSearchQuery(all, 10)
+		assert.Empty(t, q.Get("$search"))
+		assert.Equal(t, "receivedDateTime desc", q.Get("$orderby"))
+		assert.Equal(t, "10", q.Get("$top"))
+	}
+}
+
+func TestBuildMailSearchQuery_EscapingAndWhitespace(t *testing.T) {
+	// Backslashes and double quotes in the term must be escaped for Graph $search.
+	q := buildMailSearchQuery(`a"b\c`, 5)
+	assert.Equal(t, `"a\"b\\c"`, q.Get("$search"))
+	assert.Empty(t, q.Get("$orderby"))
+
+	// Whitespace-only is treated like listing (no $search, sorted by date).
+	q = buildMailSearchQuery("   ", 5)
+	assert.Empty(t, q.Get("$search"))
+	assert.Equal(t, "receivedDateTime desc", q.Get("$orderby"))
+
+	// Surrounding whitespace around a real term is trimmed.
+	q = buildMailSearchQuery("  hello  ", 5)
+	assert.Equal(t, `"hello"`, q.Get("$search"))
+}
+
+func TestMailSearchCmd_RunQuery(t *testing.T) {
+	var gotSearch, gotOrder string
+	mock := &testutil.MockClient{
+		GetFunc: func(ctx context.Context, path string, query url.Values) ([]byte, error) {
+			gotSearch = query.Get("$search")
+			gotOrder = query.Get("$orderby")
+			return mustJSON(map[string]interface{}{"value": []map[string]interface{}{}}), nil
+		},
+	}
+	root := &Root{ClientFactory: mockClientFactory(mock)}
+
+	// A real query sets $search and must NOT set $orderby (Graph rejects the combo).
+	_ = captureOutput(func() { _ = (&MailSearchCmd{Query: "test", Max: 10}).Run(root) })
+	assert.Equal(t, `"test"`, gotSearch)
+	assert.Empty(t, gotOrder)
+
+	// "*" lists and sorts by date, with no $search.
+	gotSearch, gotOrder = "", ""
+	_ = captureOutput(func() { _ = (&MailSearchCmd{Query: "*", Max: 10}).Run(root) })
+	assert.Empty(t, gotSearch)
+	assert.Equal(t, "receivedDateTime desc", gotOrder)
+}


### PR DESCRIPTION
## Problem
`mog mail search` (and `mail list`, which delegates to it) sent `$orderby` together with `$search`. Microsoft Graph rejects that combination for `/me/messages` (`SearchWithOrderBy: The query parameter '$orderby' is not supported with '$search'`), so every text search (`mog mail search <term>`) failed outright; only `*` / listing worked.

## Fix
- Extract query building into `buildMailSearchQuery` and apply `$orderby` only when not doing a `$search`. Listing (`*`, empty, or whitespace-only) keeps date sorting.
- Escape `\` and `"` inside the `$search` phrase so terms like `foo" bar` or `C:\Temp` don't produce a broken/altered query.
- Treat whitespace-only queries as a plain listing.

## Tests
- `buildMailSearchQuery` unit tests: search vs listing, escaping, whitespace.
- A `Run`-level test asserting via the mock client that a real query sets `$search` and no `$orderby`, and `*` does the reverse.
- `go build ./...`, `go vet ./...`, `go test ./...` pass.

Fixes #11
