### PR TITLE
feat: support MOG_TENANT_ID env var for single-tenant Azure AD apps

### DIFF
--- a/internal/graph/client.go
+++ b/internal/graph/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -21,8 +22,17 @@ var (
 	// It can be overridden for testing.
 	GraphBaseURL = "https://graph.microsoft.com/v1.0"
 	// AuthURL is the base URL for OAuth2 authentication.
-	AuthURL = "https://login.microsoftonline.com/common/oauth2/v2.0"
+	// Supports MOG_TENANT_ID env var for single-tenant apps.
+	AuthURL = initAuthURL()
 )
+
+func initAuthURL() string {
+	tenant := os.Getenv("MOG_TENANT_ID")
+	if tenant == "" {
+		tenant = "common"
+	}
+	return "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0"
+}
 
 // Client defines the interface for Microsoft Graph API operations.
 type Client interface {


### PR DESCRIPTION
## Problem

mogcli hardcodes the `/common/` OAuth2 endpoint, which doesn't work with single-tenant Azure AD app registrations. Single-tenant apps require the tenant-specific endpoint (`/\{tenant-id\}/oauth2/v2.0`), otherwise Azure returns:

```
AADSTS900144: The request body must contain the following parameter: 'device_code'
```

This affects any M365 Business user whose admin registers a single-tenant app (a common security practice).

## Solution

Adds an `initAuthURL()` function that reads the `MOG_TENANT_ID` environment variable. If set, it constructs the tenant-specific OAuth endpoint. If not set, it falls back to `/common/` — so existing behavior is completely unchanged.

## Usage

```bash
# Single-tenant app (new)
export MOG_TENANT_ID=your-tenant-id
mog auth login --client-id your-client-id

# Multi-tenant / personal accounts (unchanged)
mog auth login --client-id your-client-id
```

## Changes

- `internal/graph/client.go`: Replace hardcoded `AuthURL` with `initAuthURL()` that reads `MOG_TENANT_ID` env var (11 lines changed)

Fully backward compatible. No new dependencies.